### PR TITLE
Hotfix to fix home page title

### DIFF
--- a/_pages/home.md
+++ b/_pages/home.md
@@ -1,5 +1,6 @@
 ---
 layout: splash
+title: Rōger Nōden
 permalink: /
 hidden: true
 header:


### PR DESCRIPTION
Seems that the first header in the markdown becomes the page title. Adding the Recent Posts header change the page title, this HotFix adds a title to the YAML to force the title.