### PR TITLE
Add Netlify config for PR deploy previews

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,9 @@ updates:
     interval: daily
     time: "10:00"
   open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "10:00"
+  open-pull-requests-limit: 5

--- a/Gemfile.netlify
+++ b/Gemfile.netlify
@@ -4,6 +4,8 @@ source "https://rubygems.org"
 # safe-mode theme restrictions don't apply. Mirrors the plugin set from
 # _config.yml except jekyll-remote-theme, which is replaced by the gem.
 gem "jekyll", "~> 3.10"
+gem "kramdown-parser-gfm"
+gem "rouge"
 gem "minimal-mistakes-jekyll"
 gem "jekyll-paginate"
 gem "jekyll-sitemap"

--- a/Gemfile.netlify
+++ b/Gemfile.netlify
@@ -1,0 +1,14 @@
+source "https://rubygems.org"
+
+# Lightweight bundle for Netlify builds — no github-pages gem so its
+# safe-mode theme restrictions don't apply. Mirrors the plugin set from
+# _config.yml except jekyll-remote-theme, which is replaced by the gem.
+gem "jekyll", "~> 3.10"
+gem "minimal-mistakes-jekyll"
+gem "jekyll-paginate"
+gem "jekyll-sitemap"
+gem "jekyll-gist"
+gem "jekyll-feed"
+gem "jemoji"
+gem "jekyll-include-cache"
+gem "uri", ">= 0.13.2"

--- a/_config.yml
+++ b/_config.yml
@@ -266,6 +266,7 @@ plugins:
   - jekyll-feed
   - jemoji
   - jekyll-include-cache
+  - jekyll-remote-theme
 
 # mimic GitHub Pages with --safe
 whitelist:

--- a/_config_netlify.yml
+++ b/_config_netlify.yml
@@ -1,0 +1,5 @@
+# Override _config.yml for Netlify builds.
+# Uses the local minimal-mistakes gem instead of jekyll-remote-theme,
+# which requires an authenticated GitHub API call to download the theme.
+theme: minimal-mistakes-jekyll
+remote_theme: ""

--- a/_config_netlify.yml
+++ b/_config_netlify.yml
@@ -1,5 +1,12 @@
-# Override _config.yml for Netlify builds.
-# Uses the local minimal-mistakes gem instead of jekyll-remote-theme,
-# which requires an authenticated GitHub API call to download the theme.
+# Overrides merged on top of _config.yml for Netlify builds only.
+# Uses the local gem instead of remote_theme (no GitHub API call needed).
 theme: minimal-mistakes-jekyll
 remote_theme: ""
+# Replace the plugins array to drop jekyll-remote-theme (not needed with gem).
+plugins:
+  - jekyll-paginate
+  - jekyll-sitemap
+  - jekyll-gist
+  - jekyll-feed
+  - jemoji
+  - jekyll-include-cache

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,8 @@
 [build]
-  command = "bundle exec jekyll build --config _config.yml,_config_netlify.yml"
+  command = "bundle install && bundle exec jekyll build --config _config.yml,_config_netlify.yml"
   publish = "_site"
 
 [build.environment]
   RUBY_VERSION = "3.3.4"
   JEKYLL_ENV = "production"
+  BUNDLE_GEMFILE = "Gemfile.netlify"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "bundle exec jekyll build"
+  command = "bundle exec jekyll build --config _config.yml,_config_netlify.yml"
   publish = "_site"
 
 [build.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  command = "bundle exec jekyll build"
+  publish = "_site"
+
+[build.environment]
+  RUBY_VERSION = "3.3.4"
+  JEKYLL_ENV = "production"


### PR DESCRIPTION
Adds netlify.toml so Netlify can build the Jekyll site and serve
automatic deploy previews for every PR. Also extends dependabot to
track GitHub Actions versions on a weekly schedule.

https://claude.ai/code/session_01XYXxhqMrYPUActGmTfWjiU