### PR TITLE
Add scheduled GitHub Actions build and deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    # 16:00 UTC = 10:00 CST (exact) / 11:00 CDT (DST — cron can't track it)
+    - cron: '0 16 * * *'
+  workflow_dispatch: # manual trigger for testing
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only one deploy at a time; don't cancel in-progress runs
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          # reads .ruby-version (3.3.4); caches the bundle automatically
+          bundler-cache: true
+      - name: Build site
+        run: bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production
+          # jekyll-github-metadata needs a token; GITHUB_TOKEN is auto-provided
+          JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Replaces GitHub Pages' server-side Jekyll build (which ignores future-dated
posts) with a GitHub Actions workflow that builds the site with Jekyll and
deploys the artifact to Pages. A daily cron at 16:00 UTC (10 AM CST) ensures
posts scheduled for a given date go live automatically on that date.

https://claude.ai/code/session_01X3yt4Y7abATSpQj66qGfZX