### PR TITLE
Increase home page excerpt length (160 → 300 chars)

### DIFF
--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -25,6 +25,6 @@
       {% endif %}
     </h2>
     {% include page__meta.html type=include.type %}
-    {% if post.excerpt %}<p class="archive__item-excerpt" itemprop="description">{{ post.excerpt | markdownify | strip_html | truncate: 160 }}</p>{% endif %}
+    {% if post.excerpt %}<p class="archive__item-excerpt" itemprop="description">{{ post.excerpt | markdownify | strip_html | truncate: 300 }}</p>{% endif %}
   </article>
 </div>


### PR DESCRIPTION
## Summary

Post excerpts on the home page **Recent Posts** section (and the blog
archive) were being truncated mid-sentence. The theme's `archive-single.html`
include truncated excerpts at 160 characters, but recent post excerpts run
176–259 characters.

This bumps the truncate limit in our local `archive-single.html` override
from 160 to 300, so full two-sentence excerpts display without headroom
concerns for slightly longer future excerpts.

## Scope

- Single-line change to `_includes/archive-single.html` (an existing local
  theme override).
- Affects both the home page Recent Posts grid and the blog archive listing,
  both of which render via this include.

🤖 Generated with [Claude Code](https://claude.com/claude-code)