### PR TITLE
feat: improve AI agent readiness (llms.txt, JSON-LD, open robots)

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -2,3 +2,54 @@
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 <link rel="manifest" href="/site.webmanifest">
+
+<!-- Twitter card for social/agent previews -->
+<meta name="twitter:card" content="summary_large_image">
+
+<!-- llms.txt for AI agents (https://llmstxt.org) -->
+<link rel="llms-txt" href="/llms.txt" type="text/markdown" title="llms.txt">
+<link rel="alternate" type="text/markdown" href="/llms.txt" title="llms.txt">
+
+<!-- Entity / structured data for AI agents and search -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Person",
+      "@id": "{{ site.url }}/#person",
+      "name": "{{ site.name }}",
+      "url": "{{ site.url }}",
+      "image": "{{ '/images/Roger-1024x1024.jpeg' | absolute_url }}",
+      "jobTitle": "Vice President of Software Engineering",
+      "sameAs": [
+        "https://woof.group/@w0ger",
+        "https://github.com/W0GER",
+        "https://www.imdb.com/name/nm13461083",
+        "https://www.linkedin.com/in/rogernoden",
+        "https://letterboxd.com/w0ger"
+      ]
+    },
+    {
+      "@type": "Organization",
+      "@id": "{{ site.url }}/#organization",
+      "name": "{{ site.name }}",
+      "url": "{{ site.url }}",
+      "logo": "{{ '/images/Roger-1024x1024.jpeg' | absolute_url }}",
+      "founder": { "@id": "{{ site.url }}/#person" },
+      "sameAs": [
+        "https://woof.group/@w0ger",
+        "https://github.com/W0GER",
+        "https://www.linkedin.com/in/rogernoden"
+      ]
+    },
+    {
+      "@type": "WebSite",
+      "@id": "{{ site.url }}/#website",
+      "name": "{{ site.title }}",
+      "url": "{{ site.url }}",
+      "publisher": { "@id": "{{ site.url }}/#organization" }
+    }
+  ]
+}
+</script>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,21 @@
+---
+layout: null
+sitemap: false
+permalink: /llms-full.txt
+---
+# {{ site.title }} — Full Content
+
+> Personal website and blog of {{ site.name }}, Vice President of Software
+> Engineering at an AI-first company. This file contains the full text of every
+> post for machine consumption. Source: {{ site.url }}
+{% for post in site.posts %}
+---
+
+# {{ post.title }}
+
+URL: {{ post.url | absolute_url }}
+Date: {{ post.date | date: "%Y-%m-%d" }}
+{% if post.tags %}Tags: {{ post.tags | join: ", " }}{% endif %}
+
+{{ post.content | strip_html | normalize_whitespace }}
+{% endfor %}

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,28 @@
+---
+layout: null
+sitemap: false
+permalink: /llms.txt
+---
+# {{ site.title }}
+
+> Personal website and blog of {{ site.name }}, Vice President of Software
+> Engineering at an AI-first company. Writing on software engineering, AI,
+> engineering leadership, movies, electric vehicles, cooking, and the outdoors.
+
+## About
+
+- [About]({{ '/about' | absolute_url }}): Who Rōger is and what this site covers.
+- [Blog Posts]({{ '/posts' | absolute_url }}): Full chronological index of posts.
+- [Projects]({{ '/projects/' | absolute_url }}): Selected projects and work.
+
+## Blog posts
+{% for post in site.posts %}
+- [{{ post.title }}]({{ post.url | absolute_url }}){% if post.excerpt %}: {{ post.excerpt | strip_html | strip_newlines | truncate: 200 }}{% endif %}
+{%- endfor %}
+
+## Optional
+
+- [Categories]({{ '/categories/' | absolute_url }}): Posts grouped by category.
+- [Tags]({{ '/tags/' | absolute_url }}): Posts grouped by tag.
+- [Full text for agents]({{ '/llms-full.txt' | absolute_url }}): Concatenated full text of all posts.
+- [RSS feed]({{ '/feed.xml' | absolute_url }}): Subscribe to new posts.

--- a/robots.txt
+++ b/robots.txt
@@ -3,22 +3,33 @@ layout: null
 sitemap: false
 ---
 
+# All crawlers and AI agents are welcome.
+User-agent: *
+Allow: /
+
+# Explicitly allow major AI crawlers and assistants.
 User-agent: GPTBot
-Disallow: /
+Allow: /
 
 User-agent: ChatGPT-User
-Disallow: /
+Allow: /
 
 User-agent: OAI-SearchBot
-Disallow: /
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
 
 User-agent: FacebookBot
-Disallow: /
-
-User-agent: GPTBot
-Disallow: /
-
-User-agent: *
-Disallow: 
+Allow: /
 
 Sitemap: {{ 'sitemap.xml' | absolute_url }}


### PR DESCRIPTION
## What & why

A metaend (`metaend-grade.fly.dev`) scan graded rogernoden.com **F (35%, 7/20)** on AI/agent readiness. This PR fixes every check that's addressable from this static Jekyll repo.

## Changes

| Failing check | Fix |
|---|---|
| `robots.txt — Agents allowed` / `No AI agents blocked` | Removed `Disallow` blocks for GPTBot, ChatGPT-User, OAI-SearchBot, FacebookBot; explicitly `Allow` major AI crawlers |
| `llms.txt found` + `Markdown structure` | New `/llms.txt` (llmstxt.org spec) generated from posts + key pages |
| `llms-full.txt found` | New `/llms-full.txt` — full post text for single-fetch ingestion |
| `llms.txt linked from HTML` | `<link rel="llms-txt">` + `rel="alternate" type="text/markdown"` in `head/custom.html` |
| `Organization JSON-LD` | Person + Organization + WebSite `@graph` in `head/custom.html` |
| `twitter:card set` | `<meta name="twitter:card" content="summary_large_image">` |
| `sameAs entity links` (optional) | `sameAs` profile links in the JSON-LD |

Expected result: **7/20 → ~14/20 (≈70%, grade C).**

## Out of scope (not fixable on static hosting)

The remaining failures — `Agent UA gets non-HTML`, `Accept: JSON/text/markdown returns matching type`, `Returns preferred Content-Type`, `Structured errors (JSON 404)` — require server-side content negotiation. The live domain is behind Cloudflare, so these could later be done with a Cloudflare Worker (separate from this repo) to reach ~100%/A.

## Verification

- `bundle exec jekyll build` succeeds
- `_site/llms.txt`, `_site/llms-full.txt` (16 posts), `_site/robots.txt` generated correctly
- Both homepage JSON-LD blocks parse as valid JSON; new graph emits Person/Organization/WebSite

🤖 Generated with [Claude Code](https://claude.com/claude-code)