### PR TITLE
feat: enable Google Analytics (GA4)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -97,10 +97,10 @@ social:
 
 # Analytics
 analytics:
-  provider               : false # false (default), "google", "google-universal", "google-gtag", "custom"
+  provider               : "google-gtag" # false (default), "google", "google-universal", "google-gtag", "custom"
   google:
-    tracking_id          :
-    anonymize_ip         : # true, false (default)
+    tracking_id          : "G-Z52G07RL9E"
+    anonymize_ip         : true # true, false (default)
 
 
 # Site Author


### PR DESCRIPTION
## What

Enables Google Analytics 4 on the site using Minimal Mistakes' built-in `google-gtag` provider.

- Sets `analytics.provider` to `google-gtag`
- Sets the GA4 measurement ID (`G-Z52G07RL9E`)
- Enables `anonymize_ip: true`

## Notes

- No custom code — uses the theme's existing `_includes/analytics.html`.
- Tracking only fires in **production** (`JEKYLL_ENV=production`), which GitHub Pages sets automatically. Local `bundle exec jekyll serve` is unaffected.
- No cookie-consent banner included (deliberate choice for now); can be added later if EU/UK compliance becomes a concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)